### PR TITLE
support new domain leetcode.cn & deprecate old domain leetcode-cn.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Leetcode Helper
 
-A chrome extension helps you have fun at [leetcode.com](https://leetcode.com) and [leetcode-cn.com](https://leetcode-cn.com).
+A chrome extension helps you have fun at [leetcode.com](https://leetcode.com) and [leetcode.cn](https://leetcode.cn).
 
 [https://chrome.google.com/webstore/detail/leetcode-helper/gleoepapfjkpcijfmchfabbnldejdnoj](https://chrome.google.com/webstore/detail/leetcode-helper/gleoepapfjkpcijfmchfabbnldejdnoj)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,14 @@
 {
   "manifest_version": 3,
   "name": "Leetcode Helper",
-  "description": "This extension is a useful helper when you code at leetcode.com and leetcode-cn.com.\n1.Copy the question for markdown.",
+  "description": "This extension is a useful helper when you code at leetcode.com and leetcode.cn.\n1.Copy the question for markdown.",
   "version": "1.0.0",
   "content_scripts": [
     {
-      "matches": ["https://leetcode.com/problems/*", "https://leetcode-cn.com/problems/*"],
+      "matches": [
+        "https://leetcode.com/problems/*",
+        "https://leetcode.cn/problems/*"
+      ],
       "js": [
         "build/lhelper.js"
       ]


### PR DESCRIPTION
@4074  `leetcode-cn.com` will be deprecated soon and now it automatically redirects to the new domain `leetcode.cn` 
